### PR TITLE
User Profile

### DIFF
--- a/app/assets/stylesheets/nav.css
+++ b/app/assets/stylesheets/nav.css
@@ -38,7 +38,7 @@ nav {
   right: 0px;
 }
 
-.session_control a:not(.goog_login) {
+.session_control a:not(#Google-login) {
   color: #FFFFFF;
   text-decoration: none;
   line-height: 55px;
@@ -46,7 +46,7 @@ nav {
   margin-right: 16px;
 }
 
-.goog_login button {
+#Google-login button {
   display: block;
   width: 191px;
   height: 46px;
@@ -58,14 +58,14 @@ nav {
   margin-top: 6px;
 }
 
-.goog_login button:focus {
+#Google-login button:focus {
   background-image: url('/img/google/2x/focus.png');
 }
 
-.goog_login button:active {
+#Google-login button:active {
   background-image: url('/img/google/2x/pressed.png');
 }
 
-.goog_login button:disabled {
+#Google-login button:disabled {
   background-image: url('/img/google/2x/disabled.png');
 }

--- a/app/assets/stylesheets/user.scss
+++ b/app/assets/stylesheets/user.scss
@@ -40,3 +40,55 @@
     height: 200px;
   }
 }
+
+#user-info {
+  width: 600px;
+  margin: 0 auto;
+  min-height: 200px;
+
+  .avatar {
+    width: 160px;
+    height: 160px;
+    object-fit: cover;
+    float: left;
+    margin: 0 15px 15px 0;
+  }
+
+  .about {
+    margin-top: 15px;
+  }
+}
+
+#owned-things {
+  display: flex;
+  justify-content: space-evenly;
+
+  h3 {
+    margin-top: 0px;
+  }
+}
+
+#addresses, #vehicles {
+  flex-basis: 45%;
+  min-width: 350px;
+  background-color: #D7EDC2;
+  box-shadow: 0 0 3px;
+  box-sizing: border-box;
+  padding: 15px;
+}
+
+.address, .vehicle {
+  position: relative;
+}
+
+.address:not(:last-of-type), .vehicle:not(:last-of-type) {
+  margin-bottom: 5px;
+  padding-bottom: 5px;
+  border-bottom: #808080 1px solid
+}
+
+.address form, .vehicle form {
+  position: absolute;
+  top: 0px;
+  right: 0px;
+}

--- a/app/controllers/addresses_controller.rb
+++ b/app/controllers/addresses_controller.rb
@@ -1,0 +1,14 @@
+class AddressesController < ApplicationController
+  def update
+    make_default(params[:id]) if params[:_method] == 'patch'
+  end
+
+  private
+
+  def make_default(id)
+    Address.make_default(id)
+    if params[:user_id]
+      redirect_to profile_path
+    end
+  end
+end

--- a/app/controllers/addresses_controller.rb
+++ b/app/controllers/addresses_controller.rb
@@ -6,9 +6,15 @@ class AddressesController < ApplicationController
   private
 
   def make_default(id)
-    Address.make_default(id)
+    Address.make_default(id, owner)
     if params[:user_id]
       redirect_to profile_path
+    end
+  end
+
+  def owner
+    if params[:user_id]
+      User.find(params[:user_id])
     end
   end
 end

--- a/app/controllers/profile/base_controller.rb
+++ b/app/controllers/profile/base_controller.rb
@@ -1,0 +1,3 @@
+class Profile::BaseController < ApplicationController
+
+end

--- a/app/controllers/profile/profile_controller.rb
+++ b/app/controllers/profile/profile_controller.rb
@@ -1,0 +1,5 @@
+class Profile::ProfileController < Profile::BaseController
+  def show
+
+  end
+end

--- a/app/controllers/profile/profile_controller.rb
+++ b/app/controllers/profile/profile_controller.rb
@@ -1,5 +1,7 @@
 class Profile::ProfileController < Profile::BaseController
   def show
-
+    render locals: {
+      user: current_user
+    }
   end
 end

--- a/app/controllers/vehicles_controller.rb
+++ b/app/controllers/vehicles_controller.rb
@@ -1,0 +1,20 @@
+class VehiclesController < ApplicationController
+  def update
+    make_default(params[:id]) if params[:_method] == 'patch'
+  end
+
+  private
+
+  def make_default(id)
+    Vehicle.make_default(id, owner)
+    if params[:user_id]
+      redirect_to profile_path
+    end
+  end
+
+  def owner
+    if params[:user_id]
+      User.find(params[:user_id])
+    end
+  end
+end

--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -5,4 +5,9 @@ class Address < ApplicationRecord
 
   validates_presence_of %i[line_1 city state zip]
   validates :zip, format: /\A\d{5}\z/
+
+  def self.make_default(id, owner)
+    find_by(owner: owner, default: true).toggle!(:default)
+    find(id).toggle!(:default)
+  end
 end

--- a/app/models/vehicle.rb
+++ b/app/models/vehicle.rb
@@ -16,4 +16,9 @@ class Vehicle < ApplicationRecord
   validates :fuel_efficiency, numericality: {
                                 greater_than: 0
                               }
+
+  def self.make_default(id, owner)
+    find_by(owner: owner, default: true).toggle!(:default)
+    find(id).toggle!(:default)
+  end
 end

--- a/app/views/profile/profile/show.html.erb
+++ b/app/views/profile/profile/show.html.erb
@@ -8,12 +8,12 @@
 
   <section id="addresses">
   <% user.addresses.each do |address| %>
-    <article class="address<%= " default" if address.default? %>">
-      <span class="line_1"><%= address.line_1 %></span><br>
-      <span class="line_1"><%= address.line_2 %></span><br>
-      <span class="line_1"><%= address.city %></span>,
-      <span class="line_1"><%= address.state %></span>
-      <span class="line_1"><%= address.zip %></span>
+    <article class="address <%= " default" if address.default? %>">
+      <span class="line-1"><%= address.line_1 %></span><br>
+      <span class="line-2"><%= address.line_2 %></span><br>
+      <span class="city"><%= address.city %></span>,
+      <span class="state"><%= address.state %></span>
+      <span class="zip"><%= address.zip %></span>
       <% unless address.default? %>
       <%= button_to 'Make Default', user_address_path(user, address), method: :patch %>
       <% end %>

--- a/app/views/profile/profile/show.html.erb
+++ b/app/views/profile/profile/show.html.erb
@@ -14,6 +14,9 @@
       <span class="line_1"><%= address.city %></span>,
       <span class="line_1"><%= address.state %></span>
       <span class="line_1"><%= address.zip %></span>
+      <% unless address.default? %>
+      <%= button_to 'Make Default', user_address_path(user, address), method: :patch %>
+      <% end %>
     </article>
   <% end %>
   </section>

--- a/app/views/profile/profile/show.html.erb
+++ b/app/views/profile/profile/show.html.erb
@@ -1,40 +1,44 @@
 <main id="user-profile">
   <section id="user-info">
     <img class="avatar" src="<%= user.avatar_image %>">
-    <span class="name"><%= user.full_name %></span>
+    <span class="name"><%= user.full_name %></span><br>
     <span class="email"><%= user.email %></span>
     <article class="about"><%= user.about %></article>
   </section>
 
-  <section id="addresses">
-  <% user.addresses.each do |address| %>
-    <article class="address <%= " default" if address.default? %>">
-      <span class="line-1"><%= address.line_1 %></span><br>
-      <span class="line-2"><%= address.line_2 %></span><br>
-      <span class="city"><%= address.city %></span>,
-      <span class="state"><%= address.state %></span>
-      <span class="zip"><%= address.zip %></span>
-      <% unless address.default? %>
-      <%= button_to 'Make Default', user_address_path(user, address), method: :patch %>
-      <% end %>
-    </article>
-  <% end %>
-  </section>
+  <section id="owned-things">
+    <section id="addresses">
+      <h3>Pickup/Dropoff Addresses</h3>
+    <% user.addresses.each do |address| %>
+      <article class="address <%= " default" if address.default? %>">
+        <span class="line-1"><%= address.line_1 %></span><br>
+        <% if address.line_2 %><span class="line-2"><%= address.line_2 %></span><br><% end %>
+        <span class="city"><%= address.city %></span>,
+        <span class="state"><%= address.state %></span>
+        <span class="zip"><%= address.zip %></span>
+        <% unless address.default? %>
+        <%= button_to 'Make Default', user_address_path(user, address), method: :patch %>
+        <% end %>
+      </article>
+    <% end %>
+    </section>
 
-  <section id="vehicles">
-  <% user.vehicles.each do |vehicle| %>
-    <article class="vehicle<%= " default" if vehicle.default? %>">
-      <span class="make"><%= vehicle.make %></span><br>
-      <span class="model"><%= vehicle.model %></span><br>
-      <span class="color"><%= vehicle.color %></span><br>
-      <span class="year"><%= vehicle.year %></span>,
-      <span class="passenger_limit">Passenger Limit: <%= vehicle.passenger_limit %></span>
-      <span class="fuel-efficiency"><%= vehicle.fuel_efficiency %> <%= vehicle.fuel_efficiency_unit %></span>
-      <span class="fuel-type"><%= vehicle.fuel_type %></span>
-      <% unless vehicle.default? %>
-      <%= button_to 'Make Default', user_vehicle_path(user, vehicle), method: :patch %>
-      <% end %>
-    </article>
-  <% end %>
+    <section id="vehicles">
+      <h3>Vehicles</h3>
+    <% user.vehicles.each do |vehicle| %>
+      <article class="vehicle<%= " default" if vehicle.default? %>">
+        <span class="color"><%= vehicle.color %></span>
+        <span class="year"><%= vehicle.year %></span>
+        <span class="make"><%= vehicle.make %></span>
+        <span class="model"><%= vehicle.model %></span><br>
+        <span class="fuel-efficiency"><%= vehicle.fuel_efficiency %> <%= vehicle.fuel_efficiency_unit %></span>
+        <span class="fuel-type"><%= vehicle.fuel_type %></span><br>
+        <span class="passenger_limit">Passenger Limit: <%= vehicle.passenger_limit %></span>
+        <% unless vehicle.default? %>
+        <%= button_to 'Make Default', user_vehicle_path(user, vehicle), method: :patch %>
+        <% end %>
+      </article>
+    <% end %>
+    </section>
   </section>
 </main>

--- a/app/views/profile/profile/show.html.erb
+++ b/app/views/profile/profile/show.html.erb
@@ -5,4 +5,16 @@
     <span class="email"><%= user.email %></span>
     <article class="about"><%= user.about %></article>
   </section>
+
+  <section id="addresses">
+  <% user.addresses.each do |address| %>
+    <article class="address<%= " default" if address.default? %>">
+      <span class="line_1"><%= address.line_1 %></span><br>
+      <span class="line_1"><%= address.line_2 %></span><br>
+      <span class="line_1"><%= address.city %></span>,
+      <span class="line_1"><%= address.state %></span>
+      <span class="line_1"><%= address.zip %></span>
+    </article>
+  <% end %>
+  </section>
 </main>

--- a/app/views/profile/profile/show.html.erb
+++ b/app/views/profile/profile/show.html.erb
@@ -20,4 +20,21 @@
     </article>
   <% end %>
   </section>
+
+  <section id="vehicles">
+  <% user.vehicles.each do |vehicle| %>
+    <article class="vehicle<%= " default" if vehicle.default? %>">
+      <span class="make"><%= vehicle.make %></span><br>
+      <span class="model"><%= vehicle.model %></span><br>
+      <span class="color"><%= vehicle.color %></span><br>
+      <span class="year"><%= vehicle.year %></span>,
+      <span class="passenger_limit">Passenger Limit: <%= vehicle.passenger_limit %></span>
+      <span class="fuel-efficiency"><%= vehicle.fuel_efficiency %> <%= vehicle.fuel_efficiency_unit %></span>
+      <span class="fuel-type"><%= vehicle.fuel_type %></span>
+      <% unless vehicle.default? %>
+      <%= button_to 'Make Default', user_vehicle_path(user, vehicle), method: :patch %>
+      <% end %>
+    </article>
+  <% end %>
+  </section>
 </main>

--- a/app/views/profile/profile/show.html.erb
+++ b/app/views/profile/profile/show.html.erb
@@ -1,0 +1,8 @@
+<main id="user-profile">
+  <section id="user-info">
+    <img class="avatar" src="<%= user.avatar_image %>">
+    <span class="name"><%= user.full_name %></span>
+    <span class="email"><%= user.email %></span>
+    <article class="about"><%= user.about %></article>
+  </section>
+</main>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,9 @@ Rails.application.routes.draw do
 
   resources :users, only: [:new, :create]
 
+  namespace :profile do
+    get '/', to: 'profile#show'
+  end
 
   namespace :admin do
     resources :projects, only: [:new, :create, :show]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,7 @@ Rails.application.routes.draw do
 
   resources :users, only: [:new, :create] do
     resources :addresses, only: [:update]
+    resources :vehicles, only: [:update]
   end
 
   namespace :profile do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,10 +4,13 @@ Rails.application.routes.draw do
   get '/auth/:provider/callback', to: 'sessions#create'
   get '/logout', to: 'sessions#destroy'
 
-  resources :users, only: [:new, :create]
+  resources :users, only: [:new, :create] do
+    resources :addresses, only: [:update]
+  end
 
   namespace :profile do
     get '/', to: 'profile#show'
+    get '/edit', to: 'profile#edit'
   end
 
   namespace :admin do

--- a/spec/features/user/profile_spec.rb
+++ b/spec/features/user/profile_spec.rb
@@ -115,7 +115,7 @@ RSpec.describe 'as a logged in user' do
           expect(page).to_not have_content(@vehicle2.make)
         end
 
-        within('.vehicle:first-of-type') do
+        within('.vehicle:last-of-type') do
           click_on 'Make Default'
         end
       end

--- a/spec/features/user/profile_spec.rb
+++ b/spec/features/user/profile_spec.rb
@@ -1,0 +1,129 @@
+require 'rails_helper'
+
+RSpec.describe 'as a logged in user' do
+  context 'on my profile page' do
+    before :each do
+      @user = User.create(full_name: 'Volunteer',
+                              email: 'volunteer@email.com',
+                              about: 'A little about myself, very little',
+                       avatar_image: 'link to image',
+                       google_token: 'google token',
+                          google_id: 2,
+                               role: :default,
+                             active: true)
+
+      @address1 = Address.create(owner: @user,
+                                line_1: "In a van",
+                                line_2: "down by the river",
+                                  city: "Speakerville",
+                                 state: 'WA',
+                                   zip: '12345',
+                               default: false)
+
+      @address2 = Address.create(owner: @user,
+                                line_1: "Wabash and Lake",
+                                line_2: "near the ringing phone",
+                                  city: "Chicago",
+                                 state: 'IL',
+                                   zip: '12345',
+                               default: true)
+
+      @address3 = Address.create(owner: @user,
+                                line_1: "Market and 17th",
+                                line_2: "east corner",
+                                  city: "Denver",
+                                 state: 'CO',
+                                   zip: '12345',
+                               default: false)
+
+      @vehicle1 = Vehicle.create(owner: @user,
+                                  make: "Honda",
+                                 model: "Insight",
+                                 color: "Blue",
+                                  year: "2019",
+                       fuel_efficiency: 55,
+                  fuel_efficiency_unit: "MPG",
+                             fuel_type: "Gasoline",
+                       passenger_limit: 4,
+                                 image: "url/to/image",
+                               default: true)
+
+      @vehicle2 = Vehicle.create(owner: @user,
+                                  make: "Chevrolet",
+                                 model: "Suburban",
+                                 color: "Blue",
+                                  year: "1988",
+                       fuel_efficiency: 12,
+                  fuel_efficiency_unit: "MPG",
+                             fuel_type: "Gasoline",
+                       passenger_limit: 8,
+                                 image: "url/to/image",
+                               default: false)
+
+      visit profile_path
+    end
+
+    it 'can see my profile information' do
+      within '#user-info' do
+        expect(page).to have_content(@user.full_name)
+        expect(page).to have_content(@user.email)
+        expect(page).to have_content(@user.about)
+        expect(page).to have_selector("img[src='#{@user.avatar_image}']")
+      end
+    end
+
+    xit 'can see my address information and select my default' do
+      within '#addresses' do
+        expect(page).to have_selector('.address', count: 3)
+
+        within '.address.default' do
+          expect(page).to have_content(@address2.line_1)
+          expect(page).to have_content(@address2.line_2)
+          expect(page).to have_content(@address2.city)
+          expect(page).to have_content(@address2.state)
+          expect(page).to have_content(@address2.zip)
+
+          expect(page).to_not have_content(@address1.line_1)
+        end
+      end
+
+      within last('.address') do
+        click_on 'Make Default'
+      end
+
+      within '.address.default' do
+        expect(page).to have_content(@address3.line_1)
+
+        expect(page).to_not have_content(@address2.line_1)
+      end
+    end
+
+    xit 'can see my vehicle information and select my default' do
+      within '#vehicles' do
+        expect(page).to have_selector('.vehicle', count: 2)
+
+        within '.vehicle.default' do
+          expect(page).to have_content(@vehicle1.make)
+          expect(page).to have_content(@vehicle1.model)
+          expect(page).to have_content(@vehicle1.color)
+          expect(page).to have_content(@vehicle1.year)
+          expect(page).to have_content(@vehicle1.fuel_type)
+          expect(page).to have_content("#{@vehicle1.fuel_efficiency} #{@vehicle1.fuel_efficiency_unit}")
+          expect(page).to have_content("Passenger Limit: #{@vehicle1.passenger_limit}")
+
+          expect(page).to_not have_content(@vehicle2.make)
+        end
+      end
+
+      within last('.vehicle') do
+        click_on 'Make Default'
+      end
+
+      within '.vehicle.default' do
+        expect(page).to have_content(@vehicle2.make)
+
+        expect(page).to_not have_content(@vehicle1.make)
+      end
+    end
+  end
+end

--- a/spec/features/user/profile_spec.rb
+++ b/spec/features/user/profile_spec.rb
@@ -86,10 +86,10 @@ RSpec.describe 'as a logged in user' do
 
           expect(page).to_not have_content(@address1.line_1)
         end
-      end
 
-      all('.address').last do
-        click_on 'Make Default'
+        within('.address:last-of-type') do
+          click_button 'Make Default'
+        end
       end
 
       within '.address.default' do
@@ -114,10 +114,10 @@ RSpec.describe 'as a logged in user' do
 
           expect(page).to_not have_content(@vehicle2.make)
         end
-      end
 
-      all('.vehicle').last do
-        click_on 'Make Default'
+        within('.vehicle:last-of-type') do
+          click_on 'Make Default'
+        end
       end
 
       within '.vehicle.default' do

--- a/spec/features/user/profile_spec.rb
+++ b/spec/features/user/profile_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe 'as a logged in user' do
       end
     end
 
-    xit 'can see my address information and select my default' do
+    it 'can see my address information and select my default' do
       within '#addresses' do
         expect(page).to have_selector('.address', count: 3)
 
@@ -88,7 +88,7 @@ RSpec.describe 'as a logged in user' do
         end
       end
 
-      within last('.address') do
+      all('.address').last do
         click_on 'Make Default'
       end
 
@@ -116,7 +116,7 @@ RSpec.describe 'as a logged in user' do
         end
       end
 
-      within last('.vehicle') do
+      all('.vehicle').last do
         click_on 'Make Default'
       end
 

--- a/spec/features/user/profile_spec.rb
+++ b/spec/features/user/profile_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe 'as a logged in user' do
                                  image: "url/to/image",
                                default: false)
 
-      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@user)
+      allow_any_instance_of(ApplicationController).to receive(:session).and_return({user_id: @user.id})
       visit profile_path
     end
 
@@ -87,7 +87,7 @@ RSpec.describe 'as a logged in user' do
           expect(page).to_not have_content(@address1.line_1)
         end
 
-        within('.address:last-of-type') do
+        within('.address:first-of-type') do
           click_button 'Make Default'
         end
       end
@@ -99,7 +99,7 @@ RSpec.describe 'as a logged in user' do
       end
     end
 
-    xit 'can see my vehicle information and select my default' do
+    it 'can see my vehicle information and select my default' do
       within '#vehicles' do
         expect(page).to have_selector('.vehicle', count: 2)
 
@@ -115,7 +115,7 @@ RSpec.describe 'as a logged in user' do
           expect(page).to_not have_content(@vehicle2.make)
         end
 
-        within('.vehicle:last-of-type') do
+        within('.vehicle:first-of-type') do
           click_on 'Make Default'
         end
       end

--- a/spec/features/user/profile_spec.rb
+++ b/spec/features/user/profile_spec.rb
@@ -60,6 +60,7 @@ RSpec.describe 'as a logged in user' do
                                  image: "url/to/image",
                                default: false)
 
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@user)
       visit profile_path
     end
 


### PR DESCRIPTION
Completes user story https://www.pivotaltracker.com/story/show/166228292

Adds a user profile page at `/profile` (navigation link will be added in next PR)
Users can view their profile, as well as any addresses and vehicles they've added. 
If a user has multiple addresses or vehicles, they can change the default.

Note: At this time, adding addresses/vehicles is not yet implemented. In order to test functionality in localhost environment, I created an account then manually moved the Google token and ID over to an existing seed user with addresses/vehicles.