### PR TITLE
Admin dashboard

### DIFF
--- a/app/controllers/admin/projects_controller.rb
+++ b/app/controllers/admin/projects_controller.rb
@@ -39,6 +39,13 @@ class Admin::ProjectsController < Admin::BaseController
     end
   end
 
+  def destroy
+    project = Project.find(params[:id])
+    project.destroy
+    flash[:success] = "Project successfully deleted!"
+    redirect_to admin_dashboard_path
+  end
+
   private
 
   def project_params

--- a/app/controllers/admin/projects_controller.rb
+++ b/app/controllers/admin/projects_controller.rb
@@ -31,7 +31,7 @@ class Admin::ProjectsController < Admin::BaseController
   def update
     project = Project.find(params[:id])
     if project.update(project_params)
-      if Address.update(location_params.merge(owner: project))
+      if project.location.update(location_params.merge(owner: project))
         flash[:success] = "Your project was updated successfully!!"
         redirect_to admin_dashboard_path
       else

--- a/app/controllers/admin/projects_controller.rb
+++ b/app/controllers/admin/projects_controller.rb
@@ -20,11 +20,23 @@ class Admin::ProjectsController < Admin::BaseController
   end
 
   def edit
-    # binding.pry
     @project = Project.find(params[:id])
-    @address = Address.where(owner_id: @project)
-    # binding.pry
+  end
 
+  def update
+    project = Project.find(params[:id])
+    if project.update(project_params)
+      if Address.update(location_params.merge(owner: project))
+        flash[:success] = "Your project was updated successfully!!"
+        redirect_to admin_dashboard_path
+      else
+        flash[:alert] = "Invalid entry. Please try again."
+        redirect_to edit_admin_project_path(project)
+      end
+    else
+      flash[:alert] = "Invalid entry. Please try again."
+      redirect_to edit_admin_project_path(project)
+    end
   end
 
   private

--- a/app/controllers/admin/projects_controller.rb
+++ b/app/controllers/admin/projects_controller.rb
@@ -5,10 +5,15 @@ class Admin::ProjectsController < Admin::BaseController
   end
 
   def create
-    project = Project.create(project_params)
-    Address.create(location_params.merge(owner: project))
-    flash[:success] = "Your project was successfully created!"
-    redirect_to admin_project_path(project.id)
+    project = Project.new(project_params)
+    if project.save
+      Address.create(location_params.merge(owner: project))
+      flash[:success] = "Your project was successfully created!"
+      redirect_to admin_project_path(project)
+    else
+      flash[:alert] = "Invalid input. Please try again"
+      redirect_to new_admin_project_path
+    end
   end
 
   def show
@@ -41,6 +46,7 @@ class Admin::ProjectsController < Admin::BaseController
 
   def destroy
     project = Project.find(params[:id])
+    project.location.destroy
     project.destroy
     flash[:success] = "Project successfully deleted!"
     redirect_to admin_dashboard_path

--- a/app/controllers/admin/projects_controller.rb
+++ b/app/controllers/admin/projects_controller.rb
@@ -19,6 +19,14 @@ class Admin::ProjectsController < Admin::BaseController
     @projects = Project.all
   end
 
+  def edit
+    # binding.pry
+    @project = Project.find(params[:id])
+    @address = Address.where(owner_id: @project)
+    # binding.pry
+
+  end
+
   private
 
   def project_params

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -1,6 +1,6 @@
 class Project < ApplicationRecord
   belongs_to :organizer, foreign_key: 'organizer_id', class_name: :User
-  has_one :location, as: :owner, class_name: :Address, dependent: :destroy
+  has_one :location, as: :owner, class_name: :Address
   has_many :carpools
 
   validates_presence_of %i[title date description image]

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -1,6 +1,6 @@
 class Project < ApplicationRecord
   belongs_to :organizer, foreign_key: 'organizer_id', class_name: :User
-  has_one :location, as: :owner, class_name: :Address
+  has_one :location, as: :owner, class_name: :Address, dependent: :destroy
   has_many :carpools
 
   validates_presence_of %i[title date description image]

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -4,7 +4,7 @@ class Project < ApplicationRecord
   has_many :carpools
 
   validates_presence_of %i[title date description image]
-  validate :date_must_be_current, on: :create
+  validate :date_must_be_current, on: [:create, :update]
 
   def date_must_be_current
     errors.add(:date, "cannot be in the past") if date && date < Date.today

--- a/app/views/admin/projects/edit.html.erb
+++ b/app/views/admin/projects/edit.html.erb
@@ -1,0 +1,29 @@
+<main>
+  <h3>Edit a Project</h3>
+  <div class="edit-project-form">
+    <%= form_for [:admin, @project], action: :edit do |f| %>
+      <%= f.label :title %>
+      <%= f.text_field :title %>
+      <%= f.label :date %>
+      <%= f.text_field :date %>
+      <%= f.label :image %>
+      <%= f.text_field :image %>
+      <%= f.label :description %>
+      <%= f.text_field :description %>
+      <%= tag.label 'Address Line 1', for: 'address_line_1' %>
+      <%= tag.input type: :text, value: @project.location.line_1, name: 'address[line_1]', id: :address_line_1 %><br>
+      <%= tag.label 'Address Line 2', for: 'address_line_2' %>
+      <%= tag.input type: :text, value: @project.location.line_2, name: 'address[line_2]', id: :address_line_2 %><br>
+      <%= tag.label 'City', for: 'address_city' %>
+      <%= tag.input type: :text, value: @project.location.city, name: 'address[city]', id: :address_city %><br>
+      <%= tag.select name: 'address[state]', id: :address_state do %>
+        <%= options_for_select(Address.states.map{|opt|opt.first}, selected: @project.location.state) %>
+      <% end %>
+      <%= tag.label 'Zip', for: 'address_zip' %>
+      <%= tag.input type: :text, value: @project.location.zip, name: 'address[zip]', id: :address_zip %><br>
+      <%= f.label :active %>
+      <%= f.check_box :active %>
+      <%= f.submit %>
+    <% end %>
+  </div>
+</main>

--- a/app/views/admin/projects/index.html.erb
+++ b/app/views/admin/projects/index.html.erb
@@ -1,10 +1,10 @@
 <%= link_to 'Add Project', new_admin_project_path %>
 
-  <h1>Your Current Projects</h1>
+  <h1>All Projects</h1>
 
   <% @projects.each do |project| %>
   <section class="project-<%= project.id %>">
-    <h3><%= link_to project.title, admin_project_path(project) %></h3>
+    <h3><%= link_to project.title, admin_project_path(project) %> Active: <%= project.active %></h3>
     <time datetime="<%= project.date %>"><%= project.date.strftime('%A, %b %-d, %Y') %></time>
     <div id="info-<%= project.id %>">
       <p>

--- a/app/views/admin/projects/index.html.erb
+++ b/app/views/admin/projects/index.html.erb
@@ -4,7 +4,7 @@
 
   <% @projects.each do |project| %>
   <section class="project-<%= project.id %>">
-    <h3><%= project.title %></h3>
+    <h3><%= link_to project.title, admin_project_path(project) %></h3>
     <time datetime="<%= project.date %>"><%= project.date.strftime('%A, %b %-d, %Y') %></time>
     <div id="info-<%= project.id %>">
       <p>

--- a/app/views/admin/projects/show.html.erb
+++ b/app/views/admin/projects/show.html.erb
@@ -1,1 +1,15 @@
 <h2><%= @project.title %></h2>
+<time datetime="<%= @project.date %>"><%= @project.date.strftime('%A, %b %-d, %Y') %></time>
+<div id="info-<%= @project.id %>">
+  <p>
+    <%= @project.location.line_1 %><br>
+    <%= @project.location.line_2 %><br>
+    <%= @project.location.city %>,
+    <%= @project.location.state %>
+    <%= @project.location.zip %>
+  </p>
+  <h4>Project Description</h4>
+  <span><%= @project.description%></span>
+</div>
+<%= link_to "Delete Project" %>
+<%= link_to "Edit Project" %>

--- a/app/views/admin/projects/show.html.erb
+++ b/app/views/admin/projects/show.html.erb
@@ -12,5 +12,5 @@
   <h4>Project Description</h4>
   <span><%= @project.description%></span>
 </div>
+<%= link_to "Edit Project", edit_admin_project_path(@project) %>
 <%= link_to "Delete Project" %>
-<%= link_to "Edit Project" %>

--- a/app/views/admin/projects/show.html.erb
+++ b/app/views/admin/projects/show.html.erb
@@ -1,4 +1,5 @@
 <h2><%= @project.title %></h2>
+<img class"thumbnail" src="<%= @project.image %>" alt="", width="200" height="200"> <br />
 <time datetime="<%= @project.date %>"><%= @project.date.strftime('%A, %b %-d, %Y') %></time>
 <div id="info-<%= @project.id %>">
   <p>

--- a/app/views/admin/projects/show.html.erb
+++ b/app/views/admin/projects/show.html.erb
@@ -13,4 +13,5 @@
   <span><%= @project.description%></span>
 </div>
 <%= link_to "Edit Project", edit_admin_project_path(@project) %>
-<%= link_to "Delete Project" %>
+<%= link_to "Delete Project", admin_project_path(@project), method: :delete,
+                                                            data: { confirm: "Are you sure?" }%>

--- a/app/views/admin/projects/show.html.erb
+++ b/app/views/admin/projects/show.html.erb
@@ -1,4 +1,5 @@
 <h2><%= @project.title %></h2>
+<h3>Active: <%= @project.active %></h3>
 <img class"thumbnail" src="<%= @project.image %>" alt="", width="200" height="200"> <br />
 <time datetime="<%= @project.date %>"><%= @project.date.strftime('%A, %b %-d, %Y') %></time>
 <div id="info-<%= @project.id %>">

--- a/app/views/shared/_nav.html.erb
+++ b/app/views/shared/_nav.html.erb
@@ -4,6 +4,9 @@
   </section>
   <section class="session_control">
   <% if current_user %>
+    <% if current_admin? %>
+      <%= link_to 'Admin Dashboard', admin_dashboard_path %>
+    <% end %>
     <%= link_to 'Logout', '/logout' %>
   <% else %>
     <%= render partial: 'shared/google_login' %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,7 +8,7 @@ Rails.application.routes.draw do
 
 
   namespace :admin do
-    resources :projects, only: [:new, :create, :show]
+    resources :projects, only: [:new, :create, :show, :edit]
     get '/dashboard', to: 'projects#index'
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,7 +8,7 @@ Rails.application.routes.draw do
 
 
   namespace :admin do
-    resources :projects, only: [:new, :create, :show, :edit]
+    resources :projects, only: [:new, :create, :show, :edit, :update]
     get '/dashboard', to: 'projects#index'
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,7 +8,7 @@ Rails.application.routes.draw do
 
 
   namespace :admin do
-    resources :projects, only: [:new, :create, :show, :edit, :update]
+    resources :projects, only: [:new, :create, :show, :edit, :update, :destroy]
     get '/dashboard', to: 'projects#index'
   end
 

--- a/spec/features/admins/projects/edit_spec.rb
+++ b/spec/features/admins/projects/edit_spec.rb
@@ -1,8 +1,8 @@
 require 'rails_helper'
 
 describe 'As an admin' do
-  it 'I can edit a project' do
-    admin = User.new(full_name: "Vincent",
+  before :each do
+    @admin = User.new(full_name: "Vincent",
                      email: "vincent@example.com",
                      about: "TBD",
                      avatar_image: nil,
@@ -10,24 +10,26 @@ describe 'As an admin' do
                      google_id: nil,
                      role: 2,
                      active: true)
-     project_1 = Project.create!(title: 'Shelf Lake Trail Restoration', date: "2019-05-30", organizer: admin, description: "You'll work to improve a half-mile section of the popular Shelf Lake Trail. This project is relatively small with 20-25 volunteers and tasks may be technical in nature as you install water bars, check steps, and other drainage structures as well as build new rock step stream crossings. If you are new to trail work, don't worry! No previous experience is required; just be prepared to work hard at high altitude among classic Colorado views.", active: true, image: 'https://www.voc.org/sites/default/files/styles/760x420/public/op_images/ShelfLake_8.jpg?itok=_ZH6V4li')
-     address_1 = Address.create!(owner: project_1, line_1: "Shelf Lake Trailhead", line_2: "Co Rd 1038", city: "Grant", state: "CO", zip: "80448")
+     @project_1 = Project.create!(title: 'Shelf Lake Trail Restoration', date: "2019-05-30", organizer: @admin, description: "You'll work to improve a half-mile section of the popular Shelf Lake Trail. This project is relatively small with 20-25 volunteers and tasks may be technical in nature as you install water bars, check steps, and other drainage structures as well as build new rock step stream crossings. If you are new to trail work, don't worry! No previous experience is required; just be prepared to work hard at high altitude among classic Colorado views.", active: true, image: 'https://www.voc.org/sites/default/files/styles/760x420/public/op_images/ShelfLake_8.jpg?itok=_ZH6V4li')
+     @address_1 = Address.create!(owner: @project_1, line_1: "Shelf Lake Trailhead", line_2: "Co Rd 1038", city: "Grant", state: "CO", zip: "80448")
 
-     allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(admin)
+     allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@admin)
 
-     visit admin_project_path(project_1)
+     visit admin_project_path(@project_1)
      click_link "Edit Project"
+  end
 
-     expect(current_path).to eq(edit_admin_project_path(project_1))
-     expect(page.find_field('Title').value).to eq(project_1.title)
-     expect(page.find_field('Description').value).to eq(project_1.description)
+  it 'I can edit a project' do
+     expect(current_path).to eq(edit_admin_project_path(@project_1))
+     expect(page.find_field('Title').value).to eq(@project_1.title)
+     expect(page.find_field('Description').value).to eq(@project_1.description)
      expect(page.find_field('Date').value).to eq('2019-05-30')
 
-     expect(page.find_field('Address Line 1').value).to eq(project_1.location.line_1)
-     expect(page.find_field('Address Line 2').value).to eq(project_1.location.line_2)
-     expect(page.find_field('City').value).to eq(project_1.location.city)
-     expect(page.find_field('Zip').value).to eq(project_1.location.zip)
-     expect(page.find_field('Image').value).to eq(project_1.image)
+     expect(page.find_field('Address Line 1').value).to eq(@project_1.location.line_1)
+     expect(page.find_field('Address Line 2').value).to eq(@project_1.location.line_2)
+     expect(page.find_field('City').value).to eq(@project_1.location.city)
+     expect(page.find_field('Zip').value).to eq(@project_1.location.zip)
+     expect(page.find_field('Image').value).to eq(@project_1.image)
      expect(page).to have_checked_field('Active')
 
      fill_in 'Title', with: "New Project Title"
@@ -39,8 +41,20 @@ describe 'As an admin' do
 
      expect(current_path).to eq(admin_dashboard_path)
      expect(page).to have_content("Your project was updated successfully!")
-     expect(project_1.title).to eq("New Project Title")
-     expect(project_1.location.city).to eq("Fountain")
+     expect(page).to have_content("New Project Title")
+     expect(page).to have_content("Fountain")
+  end
+
+  it 'shows an error message if fields not filled out correctly' do
+    # fill_in 'Title', with: nil
+    fill_in 'Date', with: '2018-01-01'
+
+    click_button("Update Project")
+
+    expect(current_path).to eq(edit_admin_project_path(@project_1))
+    expect(page).to have_content("Invalid entry. Please try again.")
+    expect(page.find_field('Title').value).to eq(@project_1.title)
+    expect(page.find_field('Date').value).to eq('2019-05-30')
   end
 
 end

--- a/spec/features/admins/projects/edit_spec.rb
+++ b/spec/features/admins/projects/edit_spec.rb
@@ -46,7 +46,6 @@ describe 'As an admin' do
   end
 
   it 'shows an error message if fields not filled out correctly' do
-    # fill_in 'Title', with: nil
     fill_in 'Date', with: '2018-01-01'
 
     click_button("Update Project")

--- a/spec/features/admins/projects/edit_spec.rb
+++ b/spec/features/admins/projects/edit_spec.rb
@@ -19,18 +19,20 @@ describe 'As an admin' do
      click_link "Edit Project"
 
      expect(current_path).to eq(edit_admin_project_path(project_1))
-     expect(page).to have_selector("input[value='#{project_1.title}']")
-     expect(page).to have_selector("input[value='#{project_1.description}']")
-     expect(page).to have_selector("input[value='#{project_1.date}']")
-     expect(page).to have_selector("input[value='#{project_1.location.line_1}']")
-     expect(page).to have_selector("input[value='#{project_1.location.line_2}']")
-     expect(page).to have_selector("input[value='#{project_1.location.city}']")
-     expect(page).to have_selector("input[value='#{project_1.location.zip}']")
-     expect(page).to have_selector("input[value='#{project_1.image}']")
+     expect(page.find_field('Title').value).to eq(project_1.title)
+     expect(page.find_field('Description').value).to eq(project_1.description)
+     expect(page.find_field('Date').value).to eq('2019-05-30')
+
+     expect(page.find_field('Address Line 1').value).to eq(project_1.location.line_1)
+     expect(page.find_field('Address Line 2').value).to eq(project_1.location.line_2)
+     expect(page.find_field('City').value).to eq(project_1.location.city)
+     expect(page.find_field('Zip').value).to eq(project_1.location.zip)
+     expect(page.find_field('Image').value).to eq(project_1.image)
      expect(page).to have_checked_field('Active')
 
-     fill_in :title, with: "New Project Title"
+     fill_in 'Title', with: "New Project Title"
      fill_in 'address[city]', with: "Fountain"
+
      page.uncheck('Active')
 
      click_button("Update Project")
@@ -39,7 +41,6 @@ describe 'As an admin' do
      expect(page).to have_content("Your project was updated successfully!")
      expect(project_1.title).to eq("New Project Title")
      expect(project_1.location.city).to eq("Fountain")
-     # active inactive on adminproject index?
   end
 
 end

--- a/spec/features/admins/projects/edit_spec.rb
+++ b/spec/features/admins/projects/edit_spec.rb
@@ -1,0 +1,45 @@
+require 'rails_helper'
+
+describe 'As an admin' do
+  it 'I can edit a project' do
+    admin = User.new(full_name: "Vincent",
+                     email: "vincent@example.com",
+                     about: "TBD",
+                     avatar_image: nil,
+                     google_token: nil,
+                     google_id: nil,
+                     role: 2,
+                     active: true)
+     project_1 = Project.create!(title: 'Shelf Lake Trail Restoration', date: "2019-05-30", organizer: admin, description: "You'll work to improve a half-mile section of the popular Shelf Lake Trail. This project is relatively small with 20-25 volunteers and tasks may be technical in nature as you install water bars, check steps, and other drainage structures as well as build new rock step stream crossings. If you are new to trail work, don't worry! No previous experience is required; just be prepared to work hard at high altitude among classic Colorado views.", active: true, image: 'https://www.voc.org/sites/default/files/styles/760x420/public/op_images/ShelfLake_8.jpg?itok=_ZH6V4li')
+     address_1 = Address.create!(owner: project_1, line_1: "Shelf Lake Trailhead", line_2: "Co Rd 1038", city: "Grant", state: "CO", zip: "80448")
+
+     allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(admin)
+
+     visit admin_project_path(project_1)
+     click_link "Edit Project"
+
+     expect(current_path).to eq(edit_admin_project_path(project_1))
+     expect(page).to have_selector("input[value='#{project_1.title}']")
+     expect(page).to have_selector("input[value='#{project_1.description}']")
+     expect(page).to have_selector("input[value='#{project_1.date}']")
+     expect(page).to have_selector("input[value='#{project_1.location.line_1}']")
+     expect(page).to have_selector("input[value='#{project_1.location.line_2}']")
+     expect(page).to have_selector("input[value='#{project_1.location.city}']")
+     expect(page).to have_selector("input[value='#{project_1.location.zip}']")
+     expect(page).to have_selector("input[value='#{project_1.image}']")
+     expect(page).to have_checked_field('Active')
+
+     fill_in :title, with: "New Project Title"
+     fill_in 'address[city]', with: "Fountain"
+     page.uncheck('Active')
+
+     click_button("Update Project")
+
+     expect(current_path).to eq(admin_dashboard_path)
+     expect(page).to have_content("Your project was updated successfully!")
+     expect(project_1.title).to eq("New Project Title")
+     expect(project_1.location.city).to eq("Fountain")
+     # active inactive on adminproject index?
+  end
+
+end

--- a/spec/features/admins/projects/index_spec.rb
+++ b/spec/features/admins/projects/index_spec.rb
@@ -14,6 +14,8 @@ describe 'As an admin' do
                          active: true)
          project_1 = Project.create!(title: 'Shelf Lake Trail Restoration', date: "2019-05-30", organizer: admin, description: "You'll work to improve a half-mile section of the popular Shelf Lake Trail. This project is relatively small with 20-25 volunteers and tasks may be technical in nature as you install water bars, check steps, and other drainage structures as well as build new rock step stream crossings. If you are new to trail work, don't worry! No previous experience is required; just be prepared to work hard at high altitude among classic Colorado views.", active: true, image: 'https://www.voc.org/sites/default/files/styles/760x420/public/op_images/ShelfLake_8.jpg?itok=_ZH6V4li')
          address_1 = Address.create!(owner: project_1, line_1: "Shelf Lake Trailhead", line_2: "Co Rd 1038", city: "Grant", state: "CO", zip: "80448")
+         project_2 = Project.create!(title: 'Turing Trail Restoration', date: "2019-06-30", organizer: admin, description: "Let's improve Turing Trail. Technical skills required.", active: true, image: 'https://www.voc.org/sites/default/files/styles/760x420/public/op_images/GatewayMesa_12.JPG?itok=QjP5kbKV')
+         address_2 = Address.create!(owner: project_2, line_1: "Turing Trailhead", line_2: "The Basement", city: "Denver", state: "CO", zip: "80202")
 
         allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(admin)
 
@@ -31,6 +33,16 @@ describe 'As an admin' do
           expect(page).to have_content(project_1.location.city)
           expect(page).to have_content(project_1.location.zip)
         end
+
+        within ".project-#{project_2.id}" do
+          expect(page).to have_content(project_2.title)
+        end
+
+        click_link "#{project_1.title}"
+
+        expect(current_path).to eq(admin_project_path(project_1))
+        expect(page).to have_content(project_1.title)
+        expect(page).to_not have_content(project_2.title)
       end
     end
   end

--- a/spec/features/admins/projects/new_spec.rb
+++ b/spec/features/admins/projects/new_spec.rb
@@ -2,13 +2,15 @@ require 'rails_helper'
 
 describe 'As an admin' do
   describe 'when I visit /admin/dashboard I see link to add a project' do
-    it 'when I click it I can create a new project' do
-      admin = User.new(full_name: "Vincent", email: "vincent@example.com", about: "TBD", avatar_image: nil, google_token: nil, google_id: nil, role: :admin, active: true)
-      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(admin)
+    before :each do
+      @admin = User.new(full_name: "Vincent", email: "vincent@example.com", about: "TBD", avatar_image: nil, google_token: nil, google_id: nil, role: :admin, active: true)
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@admin)
 
       visit admin_dashboard_path
       click_link 'Add Project'
+    end
 
+    it 'when I click it I can create a new project' do
       expect(current_path).to eq(new_admin_project_path)
 
       fill_in 'Title', with: 'Test Project'
@@ -28,6 +30,23 @@ describe 'As an admin' do
       expect(current_path).to eq(admin_project_path(project))
       expect(page).to have_content("Your project was successfully created!")
       expect(page).to have_content(project.title)
+    end
+
+    it 'I receive an error message if the new project form is not filled out correctly' do
+      fill_in 'Title', with: 'Test Project'
+      fill_in 'Date', with: '2018-01-01'
+      fill_in 'Description', with: 'The testiest of all test projects.'
+      fill_in 'address[line_1]', with: '1331 17th St'
+      fill_in 'address[line_2]', with: 'LL100'
+      fill_in 'address[city]', with: 'Denver'
+      select 'CO', from: 'address[state]'
+      fill_in 'address[zip]', with: '80202'
+      fill_in 'Image', with: 'https://www.historycolorado.org/sites/default/files/media/images/2018/pikes-peak-1273566_1920.jpg'
+
+      click_button 'Create Project'
+
+      expect(current_path).to eq(new_admin_project_path)
+      expect(page).to have_content("Invalid input. Please try again")
     end
   end
 end

--- a/spec/features/admins/projects/show_spec.rb
+++ b/spec/features/admins/projects/show_spec.rb
@@ -2,8 +2,8 @@ require 'rails_helper'
 
 describe 'As an admin' do
   describe 'when I visit a project show page' do
-    it "I see the project info and options to delete and edit the project" do
-      admin = User.new(full_name: "Vincent",
+    before :each do
+      @admin = User.new(full_name: "Vincent",
                        email: "vincent@example.com",
                        about: "TBD",
                        avatar_image: nil,
@@ -11,20 +11,30 @@ describe 'As an admin' do
                        google_id: nil,
                        role: 2,
                        active: true)
-       project_1 = Project.create!(title: 'Shelf Lake Trail Restoration', date: "2019-05-30", organizer: admin, description: "You'll work to improve a half-mile section of the popular Shelf Lake Trail. This project is relatively small with 20-25 volunteers and tasks may be technical in nature as you install water bars, check steps, and other drainage structures as well as build new rock step stream crossings. If you are new to trail work, don't worry! No previous experience is required; just be prepared to work hard at high altitude among classic Colorado views.", active: true, image: 'https://www.voc.org/sites/default/files/styles/760x420/public/op_images/ShelfLake_8.jpg?itok=_ZH6V4li')
-       address_1 = Address.create!(owner: project_1, line_1: "Shelf Lake Trailhead", line_2: "Co Rd 1038", city: "Grant", state: "CO", zip: "80448")
+       @project_1 = Project.create!(title: 'Shelf Lake Trail Restoration', date: "2019-05-30", organizer: @admin, description: "You'll work to improve a half-mile section of the popular Shelf Lake Trail. This project is relatively small with 20-25 volunteers and tasks may be technical in nature as you install water bars, check steps, and other drainage structures as well as build new rock step stream crossings. If you are new to trail work, don't worry! No previous experience is required; just be prepared to work hard at high altitude among classic Colorado views.", active: true, image: 'https://www.voc.org/sites/default/files/styles/760x420/public/op_images/ShelfLake_8.jpg?itok=_ZH6V4li')
+       @address_1 = Address.create!(owner: @project_1, line_1: "Shelf Lake Trailhead", line_2: "Co Rd 1038", city: "Grant", state: "CO", zip: "80448")
 
-       allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(admin)
+       allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@admin)
 
-       visit admin_project_path(project_1)
+       visit admin_project_path(@project_1)
+    end
 
-       expect(current_path).to eq(admin_project_path(project_1))
-       expect(page).to have_content("#{project_1.title}")
-       expect(page).to have_content("#{project_1.date.strftime('%A, %b %-d, %Y')}")
-       expect(page).to have_content("#{project_1.location.state}")
-       expect(page).to have_content("#{project_1.description}")
+    it "I see the project info and options to delete and edit the project" do
+       expect(current_path).to eq(admin_project_path(@project_1))
+       expect(page).to have_content("#{@project_1.title}")
+       expect(page).to have_content("#{@project_1.date.strftime('%A, %b %-d, %Y')}")
+       expect(page).to have_content("#{@project_1.location.state}")
+       expect(page).to have_content("#{@project_1.description}")
        expect(page).to have_link("Delete Project")
        expect(page).to have_link("Edit Project")
+    end
+
+    it 'can delete a project by clicking the delete project link' do
+      click_link 'Delete Project'
+      expect(current_path).to eq(admin_dashboard_path)
+      expect(page).to have_content('Project successfully deleted!')
+      expect(page).to_not have_content(@project_1.title)
+      expect(page).to_not have_content(@project_1.description)
     end
   end
 end

--- a/spec/features/admins/projects/show_spec.rb
+++ b/spec/features/admins/projects/show_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+describe 'As an admin' do
+  describe 'when I visit a project show page' do
+    it "I see the project info and options to delete and edit the project" do
+      admin = User.new(full_name: "Vincent",
+                       email: "vincent@example.com",
+                       about: "TBD",
+                       avatar_image: nil,
+                       google_token: nil,
+                       google_id: nil,
+                       role: 2,
+                       active: true)
+       project_1 = Project.create!(title: 'Shelf Lake Trail Restoration', date: "2019-05-30", organizer: admin, description: "You'll work to improve a half-mile section of the popular Shelf Lake Trail. This project is relatively small with 20-25 volunteers and tasks may be technical in nature as you install water bars, check steps, and other drainage structures as well as build new rock step stream crossings. If you are new to trail work, don't worry! No previous experience is required; just be prepared to work hard at high altitude among classic Colorado views.", active: true, image: 'https://www.voc.org/sites/default/files/styles/760x420/public/op_images/ShelfLake_8.jpg?itok=_ZH6V4li')
+       address_1 = Address.create!(owner: project_1, line_1: "Shelf Lake Trailhead", line_2: "Co Rd 1038", city: "Grant", state: "CO", zip: "80448")
+
+       allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(admin)
+
+       visit admin_project_path(project_1)
+
+       expect(current_path).to eq(admin_project_path(project_1))
+       expect(page).to have_content("#{project_1.title}")
+       expect(page).to have_content("#{project_1.date.strftime('%A, %b %-d, %Y')}")
+       expect(page).to have_content("#{project_1.location.state}")
+       expect(page).to have_content("#{project_1.description}")
+       expect(page).to have_link("Delete Project")
+       expect(page).to have_link("Edit Project")
+    end
+  end
+end

--- a/spec/features/user/project_index_spec.rb
+++ b/spec/features/user/project_index_spec.rb
@@ -3,6 +3,15 @@ require 'rails_helper'
 RSpec.describe 'as a logged in user' do
   context 'on the project index page' do
     before :each do
+      @user = User.create(full_name: 'Regular User',
+                              email: 'user@email.com',
+                              about: 'Some stuff.',
+                              avatar_image: 'link to image',
+                              google_token: 'google token',
+                              google_id: 1,
+                              role: 0,
+                              active: true)
+
       @organizer = User.create(full_name: 'Project Organizer',
                               email: 'organizer@email.com',
                               about: 'A little about myself, very little',
@@ -10,6 +19,15 @@ RSpec.describe 'as a logged in user' do
                               google_token: 'google token',
                               google_id: 1,
                               role: 1,
+                              active: true)
+
+      @admin = User.create(full_name: 'Super Admin',
+                              email: 'admin@email.com',
+                              about: 'More stuff.',
+                              avatar_image: 'link to image',
+                              google_token: 'google token',
+                              google_id: 1,
+                              role: 2,
                               active: true)
 
       @project1 = Project.create(title: 'Project 1',
@@ -48,13 +66,27 @@ RSpec.describe 'as a logged in user' do
                               state: 0,
                               zip: '12345',
                               default: true)
+    end
 
+    it 'as an admin, it can see an Admin Dashboard link' do
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@admin)
       visit root_path
+
+      expect(page).to have_content("Logout")
+    end
+
+    it 'as a regular user, it does not see an Admin Dashboard link' do
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@user)
+      visit root_path
+
+      expect(page).to_not have_content("Admin Dashboard")
     end
 
     it 'can see a tile for each active project' do
       # save_and_open_page
       # the projects are ordered by default by date?
+      visit root_path
+
       expect(page).to have_content("Current Projects")
       expect(page).to_not have_content(@project3.title)
 


### PR DESCRIPTION
Closes user stories:
- Admin Dashboard: https://www.pivotaltracker.com/story/show/166228138
- Admin Visits a Project Page: https://www.pivotaltracker.com/story/show/166228182
- Admin Can Delete a Project: https://www.pivotaltracker.com/story/show/166228104
- Admin Can Enable/Disable a Project: https://www.pivotaltracker.com/story/show/166228238
- Admin Can Edit a Project: https://www.pivotaltracker.com/story/show/166228141

This completes CRUD functionality for admin (level 2).

Nav bar updated to allow for a 'Admin Dashboard' link to allow logged in admins the ability to navigate to their dashboard, where they have access to create/alter projects.

All tests passing
Coverage at 97.67%