### PR TITLE
Map display on Project Show Page

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+language: ruby
+cache: bundler
+rbenv:
+- 2.4.1
+services:
+- postgresql
+before_install:
+- gem update --system
+- gem install bundler:2.0.1
+before_script:
+- cp config/database.yml.travis config/database.yml
+- psql -c 'create database travis_ci_test;' -U postgres
+script:
+- bundle exec rspec

--- a/app/facades/project_facade.rb
+++ b/app/facades/project_facade.rb
@@ -1,5 +1,5 @@
 class ProjectFacade
-  attr_reader :title, :date, :image, :location, :carpools, :description
+  attr_reader :title, :date, :image, :location, :carpools, :description, :coordinates
   def initialize(project)
     @title = project.title
     @description = project.description
@@ -7,6 +7,7 @@ class ProjectFacade
     @image = project.image
     @location = project.location
     @carpools = project.carpools
+    @coordinates = project.format_coords
   end
 
   def no_rides?

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -9,7 +9,7 @@ class Project < ApplicationRecord
   def date_must_be_current
     errors.add(:date, "cannot be in the past") if date && date < Date.today
   end
-  
+
   def self.sorted(sort = nil)
     if sort == 'a-z'
       Project.where(active: true).order(:title)
@@ -21,5 +21,10 @@ class Project < ApplicationRecord
     else
       Project.where(active: true).order(:date)
     end
+  end
+
+  def format_coords
+    addr = self.location
+    [addr.longitude.to_f, addr.latitude.to_f]
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -42,9 +42,13 @@ class User < ApplicationRecord
   end
 
   def add_address(params)
-    Address.create(params.merge({
+    geocode = MapboxService.new
+    address = Address.new(params.merge({
                     owner: self,
                     default: needs_default?(:address)
                   }))
+    longitude,latitude = geocode.get_coords(address)[:features].first[:center]
+    address.update(longitude: longitude, latitude: latitude)
+    address.save
   end
 end

--- a/app/services/mapbox_service.rb
+++ b/app/services/mapbox_service.rb
@@ -6,6 +6,8 @@ class MapboxService
     JSON.parse(response.body, symbolize_names: true)
   end
 
+  private
+
   def api_key
     ENV['MAPBOX_TOKEN']
   end
@@ -13,12 +15,4 @@ class MapboxService
   def address_prep(address)
     (address.line_1 + '%20' + address.city + '%20' + address.state + '%20' + address.zip).gsub(/[' ']/, '%20')
   end
-
-
-  #   def get_email(github_handle)
-  #   conn = Faraday.new('https://api.github.com/users/'\
-  #     "#{github_handle}?access_token=#{@token}")
-  #   response = conn.get
-  #   JSON.parse(response.body, symbolize_names: true)
-  # end
 end

--- a/app/services/mapbox_service.rb
+++ b/app/services/mapbox_service.rb
@@ -1,0 +1,24 @@
+class MapboxService
+
+  def get_coords(address)
+    conn = Faraday.new('https://api.mapbox.com/geocoding/v5/mapbox.places/')
+    response = conn.get("#{address_prep(address) + '.json?access_token=' + api_key}")
+    JSON.parse(response.body, symbolize_names: true)
+  end
+
+  def api_key
+    ENV['MAPBOX_TOKEN']
+  end
+
+  def address_prep(address)
+    (address.line_1 + '%20' + address.city + '%20' + address.state + '%20' + address.zip).gsub(/[' ']/, '%20')
+  end
+
+
+  #   def get_email(github_handle)
+  #   conn = Faraday.new('https://api.github.com/users/'\
+  #     "#{github_handle}?access_token=#{@token}")
+  #   response = conn.get
+  #   JSON.parse(response.body, symbolize_names: true)
+  # end
+end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -8,6 +8,9 @@
     <link href="https://fonts.googleapis.com/css?family=News+Cycle:700|Open+Sans&display=swap&subset=latin-ext" rel="stylesheet">
     <%= stylesheet_link_tag    'application', media: 'all' %>
     <%= javascript_include_tag 'application' %>
+
+    <script src='https://api.mapbox.com/mapbox-gl-js/v0.54.0/mapbox-gl.js'></script>
+    <link href='https://api.mapbox.com/mapbox-gl-js/v0.54.0/mapbox-gl.css' rel='stylesheet' />
   </head>
 
   <body>

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -5,6 +5,46 @@
    <p>Project Details: <%= facade.description %></p>
    <%= link_to 'See this on google maps' %>
 </section>
+
+<section class='map'>
+  <div id='map' style='width: 400px; height: 300px;'></div>
+  <script>
+    mapboxgl.accessToken = '<%= ENV['MAPBOX_TOKEN'] %>';
+    var map = new mapboxgl.Map({
+      container: 'map',
+      style: 'mapbox://styles/mapbox/outdoors-v11',
+      center: <%= facade.coordinates %>,
+      zoom: 13,
+    });
+    map.on('load', function() {
+      map.loadImage('https://upload.wikimedia.org/wikipedia/commons/thumb/6/60/Cat_silhouette.svg/400px-Cat_silhouette.svg.png', function(error, image) {
+        if (error) throw error;
+          map.addImage('cat', image);
+          map.addLayer({
+            "id": "points",
+            "type": "symbol",
+            "source": {
+              "type": "geojson",
+              "data": {
+                "type": "FeatureCollection",
+                "features": [{
+                  "type": "Feature",
+                  "geometry": {
+                    "type": "Point",
+                    "coordinates": <%= facade.coordinates %>
+                  }
+                }]
+              }
+            },
+          "layout": {
+          "icon-image": "cat",
+          "icon-size": 0.25
+          }
+        });
+      });
+    });
+  </script>
+</section>
 <% if current_user %>
   <section class='drivers'>
     <%= button_to 'Become a Driver', projects_create_carpool_path %>

--- a/db/migrate/20190529230958_adds_coordinates_to_addresses.rb
+++ b/db/migrate/20190529230958_adds_coordinates_to_addresses.rb
@@ -1,0 +1,6 @@
+class AddsCoordinatesToAddresses < ActiveRecord::Migration[5.2]
+  def change
+    add_column :addresses, :longitude, :string
+    add_column :addresses, :latitude, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_05_22_234451) do
+ActiveRecord::Schema.define(version: 2019_05_29_230958) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -26,6 +26,8 @@ ActiveRecord::Schema.define(version: 2019_05_22_234451) do
     t.boolean "default", default: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "longitude"
+    t.string "latitude"
     t.index ["owner_type", "owner_id"], name: "index_addresses_on_owner_type_and_owner_id"
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -20,7 +20,7 @@ address_31 = Address.create!(owner: user_1, line_1: "123 Anywhere St", city: "Lo
 address_32 = Address.create!(owner: user_1, line_1: "456 Nowhere St", city: "Los Angeles", state: "CA", zip: "80206", default: false)
 
 project_1 = Project.create!(title: "Go Green!", date: "2019-05-30", organizer: user_2, description: "Plant things.", active: true, image: 'https://picsum.photos/id/1018/400/300')
-address_41 = Address.create!(owner: project_1, line_1: "At the trailhead", line_2: "Off I-70", city: "Frisco", state: "CO", zip: "80206")
+address_41 = Address.create!(owner: project_1, line_1: "At the trailhead", line_2: "Off I-70", city: "Frisco", state: "CO", zip: "80206", longitude: '-104.99625', latitude: '39.75109')
 
 project_2 = Project.create!(title: "Go Blue!", date: "2019-06-30", organizer: user_2, description: "Plant things.", active: true, image: 'https://picsum.photos/id/1015/400/300')
 address_51 = Address.create!(owner: project_2, line_1: "By the trailhead", line_2: "Off I-70", city: "Frisco", state: "CO", zip: "80206")

--- a/spec/features/user/user_addresses_spec.rb
+++ b/spec/features/user/user_addresses_spec.rb
@@ -31,5 +31,35 @@ feature 'User addresses' do
         expect(page).to have_content('In a van')
       end
     end
+
+    it 'can add lattitude and longitude to an address' do
+      user = User.create(full_name: 'Volunteer',
+                             email: 'volunteer@email.com',
+                             about: 'A little about myself, very little',
+                      avatar_image: 'link to image',
+                      google_token: 'google token',
+                         google_id: 2,
+                              role: :default,
+                            active: true)
+
+      allow_any_instance_of(ApplicationController)
+                           .to receive(:session)
+                           .and_return({user_id: user.id})
+
+                           visit profile_path
+                           click_button 'Add an Address'
+
+                           fill_in 'Line 1', with: '1331 17th st'
+                           fill_in 'Line 2', with: 'LL100'
+                           fill_in 'City', with: 'Denver'
+                           select 'CO', from: 'State'
+                           fill_in 'Zip', with: '80202'
+
+                           click_button 'Add this address'
+
+      address = Address.last
+      expect(address.longitude).to eq('-104.996446')
+      expect(address.latitude).to eq('39.750772')
+    end
   end
 end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -18,6 +18,39 @@ RSpec.describe Project, type: :model do
     it{ should validate_presence_of(:image) }
   end
 
+  describe 'instance methods' do
+    describe '#format_coords' do
+      it 'formats the longitude and latitude into a usable array for mapbox' do
+       organizer = User.create(full_name: 'Project Organizer',
+                                email: 'organizer@email.com',
+                                about: 'A little about myself, very little',
+                                avatar_image: 'link to image',
+                                google_token: 'google token',
+                                google_id: 1,
+                                role: 1,
+                                active: true)
+
+       project1 = Project.create(title: 'A Project 1',
+                                    date: '2019-07-30',
+                                    description: 'Description of Project 1',
+                                    image: 'http://clipart-library.com/image_gallery/104074.png',
+                                    organizer: organizer,
+                                    active: true)
+       address1 = Address.create(owner: project1,
+                                line_1: "first address line",
+                                line_2: "second address line",
+                                city: "city town",
+                                state: 0,
+                                zip: '12345',
+                                latitude: '13.31',
+                                longitude: '420.024',
+                                default: true)
+
+        expect(project1.format_coords).to eq([420.024, 13.31])
+      end
+    end
+  end
+
   describe 'Class Methods' do
     context '.sorted' do
       before :each do
@@ -31,21 +64,21 @@ RSpec.describe Project, type: :model do
                                 active: true)
 
         @project1 = Project.create(title: 'A Project 1',
-                                    date: '2019-07-30', 
+                                    date: '2019-07-30',
                                     description: 'Description of Project 1',
                                     image: 'http://clipart-library.com/image_gallery/104074.png',
                                     organizer: @organizer,
                                     active: true)
 
         @project2 = Project.create(title: 'C Project 2',
-                                    date: '2019-06-30', 
+                                    date: '2019-06-30',
                                     description: 'Description of Project 2',
                                     image: 'http://clipart-library.com/image_gallery/104074.png',
                                     organizer: @organizer,
                                     active: true)
 
         @project3 = Project.create(title: 'B Project 3',
-                              date: '2019-05-30', 
+                              date: '2019-05-30',
                               description: 'Description of Project 3',
                               image: 'http://clipart-library.com/image_gallery/104074.png',
                               organizer: @organizer,
@@ -75,7 +108,7 @@ RSpec.describe Project, type: :model do
                                 zip: '12345',
                                 default: true)
 
-        @vehicle1 = Vehicle.create 
+        @vehicle1 = Vehicle.create
         @carpool1 = Carpool.create(driver: @organizer, project: @project1, vehicle: @vehicle1)
       end
 
@@ -90,15 +123,12 @@ RSpec.describe Project, type: :model do
 
         expect(alphabetically).to eq([@project1, @project3, @project2])
       end
-      
+
       it 'sorts by projects that need drivers' do
         needs_driver = Project.sorted("needs_driver")
-        
+
         expect(needs_driver).to eq([@project3, @project2])
       end
     end
   end
 end
-
-
-

--- a/spec/services/mapbox_service_spec.rb
+++ b/spec/services/mapbox_service_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+describe MapboxService do
+  it 'can return longitude and latitude of a given address' do
+    user_1 = User.create!(full_name: "Jon", email: "jon@example.com", about: "TBD", avatar_image: nil, google_token: nil, google_id: nil, role: :default, active: true)
+    address = Address.create!(owner: user_1, line_1: "1331 17th st", city: "Denver", state: "CO", zip: "80206", default: true)
+    mapbox_service = MapboxService.new
+    result = mapbox_service.get_coords(address)
+
+    expect(result).to be_a(Hash)
+    expect(result[:features].first[:center]).to eq([-104.99625, 39.75109])
+  end
+end


### PR DESCRIPTION
Successfully creates and places a map on the project show page that will show pin at the projects latitude and longitude site.

When a user creates an address that address will now automatically make an API call to Mapbox's geocoder and add the latitude and longitude to that address. 

Currently projects do not have the same ability but the functionality will be different in project creation.

Currently all tests pass
Test coverage: 98.44%